### PR TITLE
Moved size/origin logic of the PaddleView and BallView

### DIFF
--- a/Breakout/Breakout/BallView.swift
+++ b/Breakout/Breakout/BallView.swift
@@ -10,6 +10,20 @@ import UIKit
 
 class BallView: UIView {
 
+    init(gameFrame: CGSize, maxWidth: CGFloat) {
+        let width = gameFrame.width / 20
+        let size = CGSize(width: width, height: width)
+        let x = (gameFrame.width - width) / 2
+        let y = (gameFrame.height + width) / 2
+        let origin = CGPoint(x: x, y: y)
+        
+        super.init(frame: CGRect(origin: origin, size: size))
+    }
+    
+    required init(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+
     /*
     // Only override drawRect: if you perform custom drawing.
     // An empty implementation adversely affects performance during animation.

--- a/Breakout/Breakout/BreakoutViewController.swift
+++ b/Breakout/Breakout/BreakoutViewController.swift
@@ -66,27 +66,14 @@ class BreakoutViewController: UIViewController, UIDynamicAnimatorDelegate {
     }
 
     func addPaddle() {
-        let width = gameView.bounds.size.width / 5
-        let height = gameView.bounds.size.height / 30
-        let size = CGSize(width: width, height: height)
-        let x = (gameView.bounds.size.width - width) / 2
-        let y = gameView.bounds.size.height - (2 * height)
-        let origin = CGPoint(x: x, y: y)
-
-        paddle = PaddleView(frame: CGRect(origin: origin, size: size))
+        paddle = PaddleView(gameFrame: gameView.bounds.size, maxWidth: 0.20)
         paddle?.backgroundColor = UIColor.blackColor()
                     breakoutBehavior.addBarrier(UIBezierPath(rect: paddle!.frame), named: "Paddle")
         self.breakoutBehavior.addPaddle(paddle!)
     }
     
     func addBall() {
-        let width = gameView.bounds.size.width / 20
-        let size = CGSize(width: width, height: width)
-        let x = (gameView.bounds.size.width - width) / 2
-        let y = (gameView.bounds.size.height + width) / 2
-        let origin = CGPoint(x: x, y: y)
-        
-        ball = BallView(frame: CGRect(origin: origin, size: size))
+        ball = BallView(gameFrame: gameView.bounds.size, maxWidth: 0.05)
         ball?.backgroundColor = UIColor.orangeColor()
         self.breakoutBehavior.addBall(ball!)
         self.breakoutBehavior.pushBall(ball!)

--- a/Breakout/Breakout/PaddleView.swift
+++ b/Breakout/Breakout/PaddleView.swift
@@ -10,6 +10,21 @@ import UIKit
 
 class PaddleView: UIView {
 
+    init(gameFrame: CGSize, maxWidth: CGFloat) {
+        let width = gameFrame.width * maxWidth
+        let height = gameFrame.height / 30
+        let size = CGSize(width: width, height: height)
+        let x = (gameFrame.width - width) / 2
+        let y = gameFrame.height - (2 * height)
+        let origin = CGPoint(x: x, y: y)
+        
+        super.init(frame: CGRect(origin: origin, size: size))
+    }
+
+    required init(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+    
     /*
     // Only override drawRect: if you perform custom drawing.
     // An empty implementation adversely affects performance during animation.


### PR DESCRIPTION
De logica van het bepalen van de size en origin van de `PaddleView` en `BallView` stond in de `addBall` en `addPaddle` functies van de `BreakoutViewController` (voorheen `GameViewController`). Ik heb deze logica verplaatst naar de `PaddleView` en `BallView`.

De `PaddleView` en `BallView` maken deel uit van deze game, daardoor kan ik er mee leven dat ze kennis hebben van het frame van de game. Dit frame is volgens mij ook bekend zodra de view een superview krijgt, maar dan ben je al voorbij je init.

Voorheen werd voor de breedte van de paddle en ball de breedte van het frame gedeeld door een getal. Dit heb ik vervangen door de parameter maxWidth, waarbij `maxWidth: 1` de volledige breedte van het scherm is, en `maxWidth: 0.5` de helft van het scherm. Ik denk dat dit gemakkelijker werkt wanneer wij een slider voor de breedte van bijvoorbeeld de paddle in de `SettingsViewController` stoppen.

Ik heb er bewust voor gekozen om de logica van de size/origin van de `BrickView` niet naar de `BrickView` te verplaatsen. Deze zou een stuk of 4 parameters krijgen (frame, bricksPerRow, numberOfRows, brickNumber) en ik wil dit daarom eerst overleggen.
